### PR TITLE
Implement Trace ingestion sample rate

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.14.1-otp-25
+erlang 25.3

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -74,8 +74,8 @@ defmodule SpandexDatadog.ApiServer do
   @spec start_link(opts :: Keyword.t()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     case Keyword.fetch(opts, :sample_rate) do
-      :error -> nil
-      {:ok, sample_rate} when sample_rate in [0.0, 1.0] -> nil
+      :error -> :ok
+      {:ok, sample_rate} when sample_rate >= 0.0 and sample_rate <= 1.0 -> :ok
       _problem -> raise ArgumentError, ":sample_rate must be a float between [0.0, 1.0]"
     end
 

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -100,6 +100,10 @@ defmodule SpandexDatadog.ApiServerTest do
   end
 
   describe "ApiServer.start_link/1" do
+    test "accepts :sample_rate as a float in range" do
+      {:ok, _pid} = ApiServer.start_link(sample_rate: 0.2)
+    end
+    
     test "raises ArgumentError if :sample_rate is invalid" do
       assert_raise ArgumentError, ":sample_rate must be a float between [0.0, 1.0]", fn ->
         ApiServer.start_link(sample_rate: 12)

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -92,10 +92,27 @@ defmodule SpandexDatadog.ApiServerTest do
           verbose?: false,
           waiting_traces: [],
           batch_size: 1,
+          sample_rate: 1.0,
           agent_pid: agent_pid
         }
       ]
     }
+  end
+
+  describe "ApiServer.start_link/1" do
+    test "raises ArgumentError if :sample_rate is invalid" do
+      assert_raise ArgumentError, ":sample_rate must be a float between [0.0, 1.0]", fn ->
+        ApiServer.start_link(sample_rate: 12)
+      end
+
+      assert_raise ArgumentError, ":sample_rate must be a float between [0.0, 1.0]", fn ->
+        ApiServer.start_link(sample_rate: -0.2)
+      end
+
+      assert_raise ArgumentError, ":sample_rate must be a float between [0.0, 1.0]", fn ->
+        ApiServer.start_link(sample_rate: "0.2")
+      end
+    end
   end
 
   describe "ApiServer.send_trace/2" do
@@ -240,6 +257,51 @@ defmodule SpandexDatadog.ApiServerTest do
       ]
 
       assert_received {:put_datadog_spans, ^formatted, ^url, ^headers}
+    end
+
+    test "only sends configured percentage of samples", %{trace: trace, state: state} do
+      :rand.seed(:default, 3_219_876)
+      state = %ApiServer.State{state | sample_rate: 0.5, verbose?: true}
+
+      log =
+        capture_log(fn ->
+          ApiServer.handle_call({:send_trace, trace}, self(), state)
+        end)
+
+      assert log =~ "Adding trace to stack with 3 spans"
+      assert_received {:put_datadog_spans, _, _, _}
+
+      log =
+        capture_log(fn ->
+          ApiServer.handle_call({:send_trace, trace}, self(), state)
+        end)
+
+      assert log =~ "Dropping trace due to 0.5 sample rate"
+      refute_received {:put_datadog_spans, _, _, _}
+
+      log =
+        capture_log(fn ->
+          ApiServer.handle_call({:send_trace, trace}, self(), state)
+        end)
+
+      assert log =~ "Adding trace to stack with 3 spans"
+      assert_received {:put_datadog_spans, _, _, _}
+    end
+
+    test "always sends samples with errors", %{trace: %{spans: [span | _rest]}, state: state} do
+      state = %ApiServer.State{state | sample_rate: 0.0, verbose?: true}
+
+      exception = RuntimeError.exception("boom")
+      span = %Span{span | error: [exception: exception]}
+      trace = %Trace{spans: [span]}
+
+      log =
+        capture_log(fn ->
+          ApiServer.handle_call({:send_trace, trace}, self(), state)
+        end)
+
+      assert log =~ "Adding trace to stack because it contains an error span"
+      assert_received {:put_datadog_spans, _, _, _}
     end
 
     test "doesn't care about the response result", %{trace: trace, state: state, url: url} do

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -326,7 +326,7 @@ defmodule SpandexDatadog.ApiServerTest do
         }
       ]
 
-      assert response =~ ~r/Trace response: {:error, %HTTPoison.Error{id: :foo, reason: :bar}}/
+      assert response =~ ~r/Trace response: {:error, %HTTPoison.Error{reason: :bar, id: :foo}}/
       assert_received {:put_datadog_spans, ^formatted, ^url, _}
     end
   end


### PR DESCRIPTION
Based on the official dd-trace library implementation: https://github.com/DataDog/dd-trace-js/blob/d3960fa432126ddcf976ed7a0e39dfb1d8b0c812/packages/dd-trace/src/sampler.js#L12-L14

Allows specifying a percentage rate of traces to be sent to DataDog. Any leftovers are discarded and not sent to DataDog.

Excludes any traces containing errors, we'll always ingest 100% of errors.

---

Background: This will allow us to tune down the ingestion rate of micro-payments, see https://www.notion.so/7mind/micro-payments-spamming-traces-d3f64110f05045d183f8deab6a16492b?pvs=4

Contribution NOTE: I've just gone ahead and built this for a much newer erlang/elixir version that the original library uses. This will not work as-is when opening a PR back to the original library, see the [accidental test run](https://app.circleci.com/pipelines/github/spandex-project/spandex_datadog/126/workflows/a8cd1e04-6685-4270-9793-d29685d58acd/jobs/118) on their Repo.